### PR TITLE
Additional Purchase Mineral button features

### DIFF
--- a/scripts/components/SpaceCartButton.js
+++ b/scripts/components/SpaceCartButton.js
@@ -1,11 +1,25 @@
-import { purchaseMineral } from "./TransientState.js"
+import { purchaseMineral, transientState } from "./TransientState.js"
 
-const handleOrderClick = (clickEvent) => {
-    if(clickEvent.target.id === "placeOrder") {
-        purchaseMineral()
+const handleOrderClick = async (clickEvent) => {
+    if (clickEvent.target.id === "placeOrder") {
 
-        // const updating = new CustomEvent("stateChanged")
-        // document.dispatchEvent(updating)
+        // Preserve governor and facility selections
+        const currentGovernorId = transientState.governorId
+        const currentFacilityId = transientState.facilityId
+        console.log(currentGovernorId, currentFacilityId)
+
+        // Invoke purchaseMineral function
+        await purchaseMineral()
+
+        // Clear the selected radio button
+        document.querySelectorAll('input[name="mineral"]').forEach(radio => radio.checked = false)
+        // Clear the space cart text
+        document.getElementById("spaceCart").innerHTML = ""
+
+        // Restore governor and facility selections
+        transientState.governorId = currentGovernorId
+        transientState.facilityId = currentFacilityId
+        console.log(transientState)
     }
 }
 

--- a/scripts/components/TransientState.js
+++ b/scripts/components/TransientState.js
@@ -1,6 +1,9 @@
-import { facilityMineralOptions } from "./facilityMinerals.js"
+import { colonyMinerals } from "../managers/colonyMineralsManager.js"
+import { facilityMinerals } from "../managers/facilityMineralsManager.js"
+import { updateColonyMineralsDOM, updateFacilityMineralsDOM } from "./updateDOM.js"
 
-const transientState = {
+// Define transientState and set intial values
+export const transientState = {
     "governorId": 0,
     "facilityId": 0,
     "colonyId": 0,
@@ -8,6 +11,7 @@ const transientState = {
     "amount": 0,
 }
 
+// Setter functions
 export const setGovernor = (chosenGovernor) => {
     transientState.governorId = chosenGovernor
     console.log(transientState)
@@ -30,22 +34,17 @@ export const setMineral = (chosenMineral) => {
     console.log(transientState)
 }
 
-
-
+// Function to update quantities of minerals when Purchase Mineral button is clicked
 export const purchaseMineral = async () => {
     // Fetch colony minerals
-    const colonyMineralResponse = await fetch("http://localhost:8088/colonyMinerals");
-    const colonyMinerals = await colonyMineralResponse.json();
+    const colonyMineralsData = await colonyMinerals()
+    // Find the specific colony mineral to add to
+    const colonyMineralToUpdate = colonyMineralsData.find(cm => cm.mineralId === transientState.mineralId && cm.colonyId === transientState.colonyId);
 
     // Fetch facility minerals
-    const facilityMineralResponse = await fetch("http://localhost:8088/facilityMinerals");
-    const facilityMinerals = await facilityMineralResponse.json();
-
+    const facilityMineralsData = await facilityMinerals()
     // Find the specific facility mineral to subtract from
-    const facilityMineralToUpdate = facilityMinerals.find(fm => fm.mineralId === transientState.mineralId && fm.facilityId === transientState.facilityId);
-
-    // Find the specific colony mineral to add to
-    const colonyMineralToUpdate = colonyMinerals.find(cm => cm.mineralId === transientState.mineralId && cm.colonyId === transientState.colonyId);
+    const facilityMineralToUpdate = facilityMineralsData.find(fm => fm.mineralId === transientState.mineralId && fm.facilityId === transientState.facilityId);
 
     // Update the facility mineral quantity
     const facilityOptions = {
@@ -95,6 +94,14 @@ export const purchaseMineral = async () => {
 
     // Dispatch event to indicate state change
     document.dispatchEvent(new CustomEvent("stateChanged"));
+
+    // Update the DOM for mineral quantities
+    await updateColonyMineralsDOM()
+    await updateFacilityMineralsDOM()
+
+    // Clear the selected mineral and amount
+    transientState.mineralId = 0
+    transientState.amount = 0
 
     console.log('Mineral transfer successful.');
 };

--- a/scripts/components/facilityList.js
+++ b/scripts/components/facilityList.js
@@ -1,12 +1,12 @@
 import { facilities } from "../managers/facilityManager.js";
-import { setFacility, setMineral } from "./TransientState.js"
+import { setFacility, setMineral, transientState } from "./TransientState.js"
 import { facilityMineralOptions } from "./facilityMinerals.js"
 import { updateSpaceCart } from "./spaceCart.js";
 
 const handleFacilityChoice = async (event) => {
     if (event.target.name === "facility") {
         const facilityId = parseInt(event.target.value)
-        setFacility(facilityId)
+        setFacility(facilityId) // Update transient state
 
         // Update minerals list for the selected facility
         const mineralsHTML = await facilityMineralOptions(facilityId)
@@ -17,31 +17,32 @@ const handleFacilityChoice = async (event) => {
             radio.addEventListener("change", (event) => {
                 const mineralId = parseInt(event.target.value)
                 setMineral(mineralId)
-                updateSpaceCart(mineralId, facilityId)
+                updateSpaceCart(mineralId, facilityId) // Update space cart based on mineral and facility
             })
         })
+
+        // Set the selected facility in the dropdown
+        document.querySelector('select[name="facility"]').value = facilityId.toString()
     }
 }
 
+// Function to build facility options dropdown
 export const facilityOptions = async () => {
-    document.addEventListener("change", handleFacilityChoice)
     const facilitiesData = await facilities()
+    const currentFacilityId = transientState.facilityId // Get current facility ID
 
     let facilityOptionsHTML ="<div id='title'>Choose a facility <select name='facility'>"
     facilityOptionsHTML += "<option value='' disabled selected>Choose a facility...</option>"
 
-    const facilityStringArray = facilitiesData.map(
-        (facility) => {
-            if (facility.status === true) {
-                return `<option value='${facility.id}'>${facility.name}</option>`
-            } else {
-                return `<option disabled value='${facility.id}'>${facility.name}</option>`
-            }
-        }
-    )
-
-    facilityOptionsHTML += facilityStringArray.join("")
+    facilitiesData.forEach(facility => {
+        // Determine if the facility should be selected based on current transient state
+        const isSelected = facility.id === currentFacilityId ? 'selected' : ''
+        facilityOptionsHTML += `<option value='${facility.id}' ${isSelected}>${facility.name}</option>`
+    })
+    
     facilityOptionsHTML += "</select></div>"
+
+    document.addEventListener("change", handleFacilityChoice)
 
     return facilityOptionsHTML
 }

--- a/scripts/components/governorList.js
+++ b/scripts/components/governorList.js
@@ -1,5 +1,5 @@
 import { governors } from "../managers/governorManager.js";
-import { setColony, setGovernor } from "./TransientState.js";
+import { setColony, setGovernor, transientState } from "./TransientState.js";
 import { getColonyMinerals } from "./colonyMinerals.js";
 
 // Function to populate governors dropdown list
@@ -15,6 +15,10 @@ export const governorList = async () => {
             option.value = governor.id
             option.textContent = `${governor.name}`
             dropdown.appendChild(option)
+
+            if (governor.id === transientState.governorId) {
+                option.selected = true // Selction the current governor
+            }
         })
     }
 
@@ -41,9 +45,12 @@ export const handleGovernorDropdownChange = async () => {
                 ${colonyMinerals.map(cm => `<li>${cm.quantity} tons of ${cm.mineral}</li>`).join("")}
             </ul>
         `
-
+        
         // Update transient state for selected governor and their colony
         setGovernor(selectedGovernor)
         setColony(governor.colonyId)
+
+        // Set the selected option in the dropdown
+        dropdown.value = selectedGovernor.toString()
     })
 }

--- a/scripts/components/main.js
+++ b/scripts/components/main.js
@@ -62,7 +62,7 @@ const render = async () => {
 
 document.addEventListener("stateChanged", async event => {
     console.log("Updating")
-    render()
+    await render()
 })
 
 render()

--- a/scripts/components/spaceCart.js
+++ b/scripts/components/spaceCart.js
@@ -1,7 +1,5 @@
 import { facilities } from "../managers/facilityManager.js"
 import { minerals } from "../managers/mineralManager.js"
-import { spaceCartButton } from "./SpaceCartButton.js"
-import { purchaseMineral } from "./TransientState.js"
 
 export const updateSpaceCart = async (mineralId, facilityId) => {
     const mineralsData = await minerals()
@@ -16,9 +14,4 @@ export const updateSpaceCart = async (mineralId, facilityId) => {
     spaceCartContainer.innerHTML = `
         <p>1 ton of ${selectedMineral.type} from ${selectedFacility.name}</p>
     `
-    
-    // const purchaseButton = document.getElementById("placeOrder")
-    // purchaseButton.addEventListener("click", () => {
-    //     purchaseMineral(selectedMineral.id)
-    // })
 }

--- a/scripts/components/updateDOM.js
+++ b/scripts/components/updateDOM.js
@@ -1,0 +1,58 @@
+import { colonies } from "../managers/colonyManager.js"
+import { colonyMinerals } from "../managers/colonyMineralsManager.js"
+import { facilities } from "../managers/facilityManager.js"
+import { facilityMinerals } from "../managers/facilityMineralsManager.js"
+import { transientState } from "./TransientState.js"
+
+// Function to update the DOM for colony minerals
+export const updateColonyMineralsDOM = async () => {
+    const colonyMineralsData = await colonyMinerals(transientState.colonyId)
+    const mineralsContainer = document.getElementById("colonyDetails")
+
+    const filteredMinerals = colonyMineralsData.filter(cm => cm.colonyId === transientState.colonyId)
+
+    // Get colonies data and find colony currently in transient state to get colony name
+    const coloniesData = await colonies()
+    const colony = coloniesData.find(colony => colony.id === transientState.colonyId)
+
+    mineralsContainer.innerHTML = `
+        <h2>${colony.name} Minerals</h2>
+        <ul>
+            ${filteredMinerals.map(cm => `<li>${cm.quantity} tons of ${cm.mineral.type}</li>`).join("")}
+        </ul>
+    `
+}
+
+// Function to update the DOM for facility minerals
+export const updateFacilityMineralsDOM = async () => {
+    // Fetch facility minerals data based on the current facility ID
+    const facilityMineralsData = await facilityMinerals(transientState.facilityId);
+    const mineralsListElement = document.getElementById("mineralsList");
+
+    // Filter facility minerals data to include only minerals for the current facility
+    const filteredMinerals = facilityMineralsData.filter(fm => fm.facilityId === transientState.facilityId)
+
+    // Store current selection before updating the DOM
+    const currentSelection = document.querySelector('input[name="mineral"]:checked')?.value
+
+    // Get facilities data and find facility currently in transient state to get facility name
+    const facilitiesData = await facilities()
+    const facility = facilitiesData.find(facility => facility.id === transientState.facilityId)
+
+    // Construct the updated HTML content for facility minerals
+    mineralsListElement.innerHTML = `
+        <h2 id="facilityMineralsTitle">Facility Minerals${facility ? ` for ${facility.name}` : ''}</h2>
+        <ul>
+            ${filteredMinerals.map(fm => `
+                <li>
+                    <input type="radio" 
+                            name="mineral" 
+                            value="${fm.mineral.id}" 
+                            id="mineral${fm.mineral.id}" ${fm.mineral.id == currentSelection ? 'checked' : ''}
+                    >
+                    <label for="mineral${fm.mineral.id}">${fm.quantity} tons of ${fm.mineral.type}</label>
+                </li>
+            `).join("")}
+        </ul>
+    `
+};

--- a/scripts/managers/colonyMineralsManager.js
+++ b/scripts/managers/colonyMineralsManager.js
@@ -1,5 +1,5 @@
 export const colonyMinerals = async () => {
-    const response = await fetch("http://localhost:8088/colonyMinerals");
+    const response = await fetch("http://localhost:8088/colonyMinerals?_expand=mineral");
     const data = await response.json();
     return data
 }

--- a/scripts/managers/facilityMineralsManager.js
+++ b/scripts/managers/facilityMineralsManager.js
@@ -1,0 +1,5 @@
+export const facilityMinerals = async () => {
+    const response = await fetch("http://localhost:8088/facilityMinerals?_expand=mineral");
+    const data = await response.json();
+    return data
+}


### PR DESCRIPTION
The following now occurs once the Purchase Mineral button is clicked:
- The Colony Minerals and Facility Minerals text areas dynamically updates once the Purchase Mineral button is clicked
- The selected radio button clears 
- The space cart text clears
- Governor and facility selections remain
- Created **updateDOM.js** to handle text updates, as well as **colonyMineralsManager.js**, which was needed for the updateColonyMinerals() function in updateDOM.js. The manager includes the expand of 'mineral' in order to get the mineral name.

Edits made to other modules: 

**facilityList.js**
1. Removed inactive facility filter since we need to keep it displayed, and instead need to deactivate the button
2. Other tweaks in order to get the selected facility to stay displayed after purchase mineral button click

**governorList.js**
1. Added selectedGovernor variable so the selected governor remains displayed after purchase mineral button click

**spaceCart.js**
1. Removed unused code initially written before PUT/POST function was created

**SpaceCartButton.js**
1. Added code that preserves/restores the governor and facility selections
3. Added code that clears selected radio button
4. Added code that clears space cart text

**TransientState.js**
1. Swapped out fetches for functions from fetch manager modules
3. Imported the update functions from updateDOM.js
4. Added code to clear selected mineral and amount from transient state