### PR TITLE
Disabled button until both a governor and facility are selected

### DIFF
--- a/scripts/components/SpaceCartButton.js
+++ b/scripts/components/SpaceCartButton.js
@@ -1,29 +1,49 @@
 import { purchaseMineral, transientState } from "./TransientState.js"
 
-const handleOrderClick = async (clickEvent) => {
-    if (clickEvent.target.id === "placeOrder") {
+// Function to check and update the state of the purchase button
+const updateSpaceCartButtonState = () => {
+    const purchaseMineralButton = document.getElementById("placeOrder")
 
-        // Preserve governor and facility selections
-        const currentGovernorId = transientState.governorId
-        const currentFacilityId = transientState.facilityId
-        console.log(currentGovernorId, currentFacilityId)
-
-        // Invoke purchaseMineral function
-        await purchaseMineral()
-
-        // Clear the selected radio button
-        document.querySelectorAll('input[name="mineral"]').forEach(radio => radio.checked = false)
-        // Clear the space cart text
-        document.getElementById("spaceCart").innerHTML = ""
-
-        // Restore governor and facility selections
-        transientState.governorId = currentGovernorId
-        transientState.facilityId = currentFacilityId
-        console.log(transientState)
+    if (transientState.governorId && transientState.colonyId && transientState.facilityId) {
+        purchaseMineralButton.disabled = false // Enable button if all conditions are met
+    } else if (purchaseMineralButton) {
+        purchaseMineralButton.disabled = true // Otherwise, disable it
     }
 }
 
-export const spaceCartButton = () => {
-    document.addEventListener("click", handleOrderClick)
-    return "<button id='placeOrder'>Purchase<br>Mineral</button>"
+const handleOrderClick = async (clickEvent) => {
+    if (clickEvent.target.id === "placeOrder") {
+        // Check if all required selections are made
+        if (transientState.governorId && transientState.colonyId && transientState.facilityId) {
+            // Preserve governor and facility selections
+            const currentGovernorId = transientState.governorId
+            const currentFacilityId = transientState.facilityId
+
+            // Invoke purchaseMineral function
+            await purchaseMineral()
+
+            // Clear the selected radio button
+            document.querySelectorAll('input[name="mineral"]').forEach(radio => radio.checked = false)
+
+            // Clear the space cart text
+            document.getElementById("spaceCart").innerHTML = ""
+
+            // Restore governor and facility selections
+            transientState.governorId = currentGovernorId
+            transientState.facilityId = currentFacilityId
+            console.log(transientState)
+        } else {
+            // Display an alert if not all selections are made
+            alert("Please select both a governor and a facility before purchasing.")
+        }
+    }
 }
+
+// Initialize the button behavior after the DOM content is fully loaded
+document.addEventListener("DOMContentLoaded", () => {
+    document.addEventListener("click", handleOrderClick)
+    updateSpaceCartButtonState() // Update button state initially
+})
+
+// Export the button creation function
+export const spaceCartButton = () => "<button id='placeOrder'>Purchase<br>Mineral</button>"


### PR DESCRIPTION
- Added code to **SpaceCartButton.js** to disable the button until both a governor and facility are selected
- Button defaults to being disabled until conditions are met
- Kept getting an error "Cannot set properties of null (setting 'disabled')" because the element with ID "placeOrder" (the button) wasn't being found in the DOM when the updateSpaceCartButtonState() function was being executed, because the script was trying to access the element before it was being loaded into the DOM. To fix this, added a "DOMContentLoaded" event listener around the "click" event listener for the button.